### PR TITLE
fix list out of rang while soup.find('ul') return empty list.

### DIFF
--- a/dokuWikiDumper/dump/content/titles.py
+++ b/dokuWikiDumper/dump/content/titles.py
@@ -53,7 +53,16 @@ def getTitlesOld(url, ns=None, ancient=False, session=None):
     depth = len(ns.split(':'))
 
     r = session.get(url, params=params)
-    soup = BeautifulSoup(r.text, os.environ.get('htmlparser')).findAll('ul', {'class': 'idx'})[0]
+    soup = BeautifulSoup(r.text, os.environ.get('htmlparser'))
+
+    if len(soup.findAll('ul', {'class': 'idx'}))==0:
+        title = soup.find('title').text.strip()
+        if "\[" in title:
+            import re
+            title = re.sub("\[.*\]","", title).strip()
+        return title
+
+    soup = soup.findAll('ul', {'class': 'idx'})[0]
     attr = 'text' if ancient else 'title'
 
     if ns:


### PR DESCRIPTION
fix list out of rang while `soup.find('ul')` return empty list.
use page title as return. if [***] in which, remove it.
for example: ASTERIX plugin for Wireshark    [plugin ASTERIX pour wireshark] -> ASTERIX plugin for Wireshark