### PR TITLE
feat: add --user-agent

### DIFF
--- a/dokuWikiDumper/dump/dokuDumper.py
+++ b/dokuWikiDumper/dump/dokuDumper.py
@@ -99,6 +99,9 @@ def getArgumentParser():
     parser.add_argument("-g", "--uploader-arg", dest="uploader_args", action='append', default=[],
                         help="Arguments for uploader.")
     parser.add_argument('--force', action='store_true', help='To dump even if a recent dump exists on IA')
+    parser.add_argument('--user-agent', dest="user_agent", type=str,
+                        default='dokuWikiDumper/' + DUMPER_VERSION + ' (https://github.com/saveweb/dokuwiki-dumper)',
+                        help=f'The User-Agent to use when making requests [default: dokuWikiDumper/{DUMPER_VERSION} ...]')
 
     return parser
 
@@ -187,7 +190,7 @@ def dump():
     url_input = args.url
     skip_to = args.skip_to
 
-    session = createSession(retries=args.retry)
+    session = createSession(retries=args.retry, user_agent=args.user_agent)
 
     if args.verbose:
         def print_request(r: requests.Response, *args, **kwargs):

--- a/dokuWikiDumper/utils/session.py
+++ b/dokuWikiDumper/utils/session.py
@@ -8,11 +8,10 @@ import time
 import requests
 import urllib3
 
-from dokuWikiDumper.__version__ import DUMPER_VERSION
 from dokuWikiDumper.utils.util import uopen
 
 
-def createSession(retries=5):
+def createSession(retries=5, user_agent=None) -> requests.Session:
     session = requests.Session()
     try:
         from requests.adapters import HTTPAdapter
@@ -68,8 +67,7 @@ def createSession(retries=5):
     except:
         pass
 
-    session.headers.update({'User-Agent': 'dokuWikiDumper/' +
-                           DUMPER_VERSION + ' (https://github.com/saveweb/dokuwiki-dumper)'})
+    session.headers.update({'User-Agent': user_agent})
     print('User-Agent:',session.headers.get('User-Agent'))
 
     return session


### PR DESCRIPTION
This PR adds a --user-agent option to change the user agent. We recently had an issue where the operator of a dokuwiki site had trouble finding us because wikibot was only able to use a custom user agent for wikiteam3, so it would be nice to use one here as well.